### PR TITLE
fix: unmocked when component rerender

### DIFF
--- a/src/__tests__/pages/Post.spec.tsx
+++ b/src/__tests__/pages/Post.spec.tsx
@@ -262,7 +262,7 @@ describe('Post', () => {
   });
 
   it('should be able to render loading message if fallback', () => {
-    mockedUseRouter.mockReturnValueOnce({
+    mockedUseRouter.mockReturnValue({
       isFallback: true,
     });
 


### PR DESCRIPTION
When component rerender the mock is lost, then it breaks the test even that the component is working correctly.