### PR TITLE
fixed tests pages/home & pages/post mock values (prismic api update)

### DIFF
--- a/src/__tests__/pages/Home.spec.tsx
+++ b/src/__tests__/pages/Home.spec.tsx
@@ -29,7 +29,7 @@ interface GetStaticPropsResult {
   props: HomeProps;
 }
 
-const mockedQueryReturn = {
+const mockedGetByTypeReturn = {
   next_page: 'link',
   results: [
     {
@@ -79,8 +79,8 @@ describe('Home', () => {
     };
 
     mockedPrismic.mockReturnValue({
-      query: () => {
-        return Promise.resolve(mockedQueryReturn);
+      getByType: () => {
+        return Promise.resolve(mockedGetByTypeReturn);
       },
     });
 

--- a/src/__tests__/pages/Post.spec.tsx
+++ b/src/__tests__/pages/Post.spec.tsx
@@ -33,16 +33,14 @@ interface GetStaticPropsResult {
   props: PostProps;
 }
 
-const mockedQueryReturn = {
-  results: [
-    {
-      uid: 'como-utilizar-hooks',
-    },
-    {
-      uid: 'criando-um-app-cra-do-zero',
-    },
-  ],
-};
+const mockedGetAllByTypeReturn = [
+  {
+    uid: 'como-utilizar-hooks',
+  },
+  {
+    uid: 'criando-um-app-cra-do-zero',
+  },
+]
 
 const mockedGetByUIDReturn = {
   uid: 'como-utilizar-hooks',
@@ -201,9 +199,9 @@ describe('Post', () => {
       getByUID: () => {
         return Promise.resolve(mockedGetByUIDReturn);
       },
-      query: () => {
-        return Promise.resolve(mockedQueryReturn);
-      },
+      getAllByType: () => {
+        return Promise.resolve(mockedGetAllByTypeReturn)
+      }
     });
   });
 


### PR DESCRIPTION
The tests on the pages home and post, was mocking the values to an older version of the prismic api return, causing errors when running `yarn test`.